### PR TITLE
시그널링 서버 인스턴스 마이그레이션 : prod 서버 실행 함수 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,11 @@ version: '3.5'
 services:
     server:
         build: .
-        environment:
-            - PORT=8083
-            - MAXIMUM=4
+        container_name: dao-signaling-server
         ports:
             - '8083:8083'
         networks:
             - docker-net
+        # TODO : 볼륨 지정
 networks:
     docker-net:

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const app = express();
 const socketio = require('socket.io');
 const { START_MESSAGE } = require('./src/common/constants/express');
 
-const initServer = async () => {
+const initLocalServer = async () => {
     await expressLoader(app);
 
     const key = fs.readFileSync('cert.key');
@@ -26,4 +26,22 @@ const initServer = async () => {
     });
 };
 
-initServer();
+const initProdServer = async () => {
+    await expressLoader(app);
+
+    const server = app.listen(config.port, () => {
+        console.log(START_MESSAGE);
+    });
+    const io = socketio.listen(server, { path: '/signaling/' });
+
+    await socketIoLoader(io);
+};
+
+switch (config.envMode) {
+    case 'prod':
+        initProdServer();
+        break;
+    default:
+        initLocalServer();
+        break;
+}


### PR DESCRIPTION
[##](url) 📝 개요

-   spring과 동일한 redis 사용 및 빠른 인증 처리를 위해 해당 인스턴스로 시그널링 서버를 마이그레이션

## ✨ 변경 사항

-   코드나 기능의 주요 변경 사항을 설명합니다.

    -   ✨ prod 서버 실행 함수 추가
    -   🔥  docker-compose 불필요한 파일 삭제 및 TODO 추가
